### PR TITLE
Poprawa błędu z nieprawidłowym przypisaniem parametrów.

### DIFF
--- a/src/Db.php
+++ b/src/Db.php
@@ -35,12 +35,7 @@ class Db
     {
         $stmt = $this->pdo->prepare($sql);
 
-        if (!empty($params) && is_array($params)) {
-            foreach ($params as $k => $v)
-                $stmt->bindParam($k, $v);
-        }
-
-        if (!$stmt->execute()) {
+        if (!$stmt->execute($params)) {
             throw new \RuntimeException("Failed to execute [$sql] {$stmt->errorInfo()[2]}");
         }
 


### PR DESCRIPTION
Funkcja pobierzWszystko nie działała poprawnie dla większej liczby parametrów

bindParam() przypisuje referencje, która po iteracji w pętli jest zmieniana (PHP wewnętrznie nie tworzy nowej zmiennej tylko zmienia wartość starej a dodatkowo jest ona dostępna po wyjścu z pętli, przez co do każdego parametru było wpisane to samo i wyszukiwanie nie działało)

https://www.php.net/manual/en/pdostatement.bindparam.php

This works ($val by reference):
<?php
foreach ($params as $key => &$val) {
    $sth->bindParam($key, $val);
}
?>

This will fail ($val by value, because bindParam needs &$variable):
<?php
foreach ($params as $key => $val) {
    $sth->bindParam($key, $val);
}
?>